### PR TITLE
Supervisord entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,13 @@ RUN apt-get update \
     && rm -rf /tmp/* && apt-get purge -y bzip2 build-essential
 
 COPY config/* /etc/trafficserver/
+COPY access_log_out.sh /opt/access_log_out.sh
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-RUN chmod 0755 /docker-entrypoint.sh && chown -R nobody:nogroup /etc/trafficserver
+RUN chmod 0755 /docker-entrypoint.sh /opt/access_log_out.sh && chown -R nobody:nogroup /etc/trafficserver
 
 EXPOSE 8080 8083
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-#CMD ["/opt/trafficserver/bin/traffic_logcat", "-f", "opt/trafficserver/var/log/trafficserver/squid.blog"]
-CMD ["tail", "-f", "opt/trafficserver/var/log/trafficserver/access.log"]
+CMD ["/opt/trafficserver/bin/traffic_cop", "-o"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=$TS_PATH/bin:$PATH
 
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install -y wget build-essential locales bzip2 libssl-dev libxml2-dev libpcre3-dev tcl-dev libboost-dev \
+    && apt-get install -y wget build-essential locales bzip2 libssl-dev libxml2-dev libpcre3-dev tcl-dev libboost-dev supervisor \
     && mkdir -p $TS_PATH \
     && wget $TS_URL -O /tmp/$TS_PKG && tar -xjf /tmp/$TS_PKG -C /tmp && cd /tmp/trafficserver-$TS_VERSION \
     && ./configure --prefix=$TS_PATH \
@@ -19,6 +19,7 @@ RUN apt-get update \
     && rm -rf /tmp/* && apt-get purge -y bzip2 build-essential
 
 COPY config/* /etc/trafficserver/
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY access_log_out.sh /opt/access_log_out.sh
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
@@ -28,4 +29,4 @@ EXPOSE 8080 8083
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-CMD ["/opt/trafficserver/bin/traffic_cop", "-o"]
+CMD ["/usr/bin/supervisord"]

--- a/access_log_out.sh
+++ b/access_log_out.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+while ! echo "GET /notvalid HTTP1.1" | nc localhost 8080 | grep HTTP
+  do
+    echo "ATS has not been started yet - `date`"
+    sleep 3
+done
+
+# temporary hardcode for testing purposes. waiting when traffic_server will create access.log
+while [ ! -f /opt/trafficserver/var/log/trafficserver/access.log ]; do
+    echo "squid.blog bin log file does not exist yet. Waiting..."
+    sleep 5
+done

--- a/access_log_out.sh
+++ b/access_log_out.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
-while ! echo "GET /notvalid HTTP1.1" | nc localhost 8080 | grep HTTP
+while ! echo -e "GET /disregard HTTP/1.1\n\n" | nc localhost 8080 | grep HTTP
   do
     echo "ATS has not been started yet - `date`"
     sleep 3
 done
 
 # temporary hardcode for testing purposes. waiting when traffic_server will create access.log
-while [ ! -f /opt/trafficserver/var/log/trafficserver/access.log ]; do
-    echo "squid.blog bin log file does not exist yet. Waiting..."
+while [ ! -f $TS_PATH/var/log/trafficserver/access.log ]; do
+    echo "access.log does not exist yet. Waiting..."
     sleep 5
 done
+
+#exec tail -f /opt/trafficserver/var/log/trafficserver/access.log
+tail -f $TS_PATH/var/log/trafficserver/access.log

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-/opt/trafficserver/bin/trafficserver start
-
-while ! echo "GET / HTTP1.1" | nc localhost 8080 | grep HTTP
-  do
-    echo "ATS has not been started yet - `date`"
-    sleep 3
-done
-
-# temporary hardcode for testing purposes. waiting when traffic_server will create squid.blog
-while [ ! -f /opt/trafficserver/var/log/trafficserver/access.log ]; do
-    echo "squid.blog bin log file does not exist yet. Waiting..."
-    sleep 5
-done
+/opt/access_log_out.sh &
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-/opt/access_log_out.sh &
 
 exec "$@"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,23 @@
+[supervisord]
+nodaemon=true
+loglevel = info
+pidfile = /tmp/supervisor.pid
+logfile = /tmp/supervisor.log
+
+[program:traffic_cop]
+command=/opt/trafficserver/bin/traffic_cop -o
+autostart=true
+autorestart=true
+#redirect_stderr=True
+#redirect_stdout=True
+
+[program:access_log_check]
+command=/opt/access_log_out.sh
+numprocs=1
+startsec=20
+startretries=10
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+


### PR DESCRIPTION
- Supervisord as supervisor for traffic_cop (From docs: traffic_cop is a watchdog program that is responsible for starting traffic_manager and traffic_server and monitoring them for responsiveness. If either of these processes are determined to be unresponsive, traffic_cop will kill and restart them.)
- Supervisord as supervisor for process with tail of access.log file to stdout.